### PR TITLE
Fix question search when no targets specified

### DIFF
--- a/modules/core/src/main/java/org/vstu/compprehension/models/businesslogic/storage/QuestionBank.java
+++ b/modules/core/src/main/java/org/vstu/compprehension/models/businesslogic/storage/QuestionBank.java
@@ -54,6 +54,12 @@ public class QuestionBank {
         return isMatch(meta, bankSearchRequest);
     }
 
+    /**
+     * Реализует логику, равносильную QuestionMetadataComplexQueriesRepository.findTopRatedMetadata, для сопоставления сгенерированного вопроса с запросом на поиск в банке.
+     * @param meta метаданные сгенерированного вопроса
+     * @param qr поисковый запрос к банку вопросов (complexity нормализована на диапазон сложности в банке)
+     * @return true, если имеет место совпадение вопроса с поисковым запросом
+     */
     public boolean isMatch(@NotNull QuestionMetadataEntity meta, @NotNull QuestionBankSearchRequest qr) {
         // Если не совпадает имя домена – мы пытаемся сделать что-то Неправильно!
         if (qr.getDomainShortname() != null && ! qr.getDomainShortname().equalsIgnoreCase(meta.getDomainShortname())) {

--- a/modules/core/src/main/java/org/vstu/compprehension/models/businesslogic/strategies/AbstractStrategy.java
+++ b/modules/core/src/main/java/org/vstu/compprehension/models/businesslogic/strategies/AbstractStrategy.java
@@ -77,7 +77,10 @@ public interface AbstractStrategy {
         ArrayList<String> deniedQuestions = new ArrayList<>();
         if (exerciseAttempt != null && exerciseAttempt.getQuestions() != null) {
             for (QuestionEntity q : exerciseAttempt.getQuestions()) {
-                deniedQuestions.add(q.getQuestionName());
+                String questionName = q.getQuestionName();
+                if (questionName != null) {
+                    deniedQuestions.add(questionName);
+                }
             }
         }
         return deniedQuestions;
@@ -155,6 +158,7 @@ public interface AbstractStrategy {
         qr.setDeniedQuestionMetaIds(exerciseAttempt.getQuestions().stream()
                 .filter(q -> q.getMetadata() != null)
                 .map(q -> q.getMetadata().getId())
+                .filter(Objects::nonNull)
                 .collect(Collectors.toList()));
 
         qr.setComplexitySearchDirection(SearchDirections.TO_SIMPLE);

--- a/modules/core/src/main/java/org/vstu/compprehension/models/repository/QuestionGenerationRequestRepository.java
+++ b/modules/core/src/main/java/org/vstu/compprehension/models/repository/QuestionGenerationRequestRepository.java
@@ -12,6 +12,11 @@ import java.util.List;
 
 @Repository
 public interface QuestionGenerationRequestRepository extends CrudRepository<QuestionGenerationRequestEntity, Integer>, QuestionGenerationRequestComplexQueriesRepository {
+    /**
+     * Обновить статус группы равносильных запросов на генерацию вопросов.
+     * При этом каждый вопрос, сгенерированный для любого из этих запросов, учитывается один раз для каждого запроса из группы.
+     * @param generationRequestIds список «сливающихся» запросов на генерацию
+     */
     @Transactional
     @Query(value = 
             "UPDATE question_generation_requests SET " +

--- a/modules/core/src/main/java/org/vstu/compprehension/models/repository/QuestionMetadataComplexQueriesRepository.java
+++ b/modules/core/src/main/java/org/vstu/compprehension/models/repository/QuestionMetadataComplexQueriesRepository.java
@@ -13,9 +13,34 @@ public interface QuestionMetadataComplexQueriesRepository {
 
     List<Integer> findMostUsedMetadataIds(@Nullable Integer weekUsageThreshold, @Nullable Integer dayUsageThreshold, @Nullable Integer hourUsageThreshold, @Nullable Integer min15UsageThreshold, @Nullable Integer min5UsageThreshold);
 
+    /**
+     * Найти самые лучше неиспользованные вопросы.
+     * (По количеству найденных вопросов также определяется потребность в генерации новых, — когда их становится слишком мало.)
+     * @param qr поисковый запрос к банку вопросов
+     * @param complexityWindow ширина допуска для сопоставления complexity
+     * @param limitNumber максимальное число вопросов в результате
+     * @return подходящие вопросы
+     */
     List<QuestionMetadataEntity> findTopRatedMetadata(QuestionBankSearchRequest qr, float complexityWindow, int limitNumber);
 
+    /**
+     * Найти хорошие, потенциально использованные вопросы.
+     * Этот метод поиска больше акцентируется на совпадении по сложности.
+     * @param qr поисковый запрос к банку вопросов
+     * @param complexityWindow ширина допуска для сопоставления complexity
+     * @param limitNumber максимальное число вопросов в результате
+     * @return подходящие вопросы
+     */
     List<QuestionMetadataEntity> findMetadata(QuestionBankSearchRequest qr, float complexityWindow, int limitNumber);
 
+    /**
+     * Найти любые минимально подходящие вопросы.
+     * Этот метод поиска требует только попадания величины solution_steps в фиксированный диапазон,
+     * остальные критерии могут быть удовлетворены не полностью и используются для сортировки кандидатов по убыванию.
+     * @param qr поисковый запрос к банку вопросов
+     * @param complexityWindow ширина допуска для сопоставления complexity
+     * @param limitNumber максимальное число вопросов в результате
+     * @return подходящие вопросы
+     */
     List<QuestionMetadataEntity> findMetadataRelaxed(QuestionBankSearchRequest qr, float complexityWindow, int limitNumber);
 }

--- a/modules/core/src/main/java/org/vstu/compprehension/models/repository/QuestionMetadataComplexQueriesRepositoryImpl.java
+++ b/modules/core/src/main/java/org/vstu/compprehension/models/repository/QuestionMetadataComplexQueriesRepositoryImpl.java
@@ -330,13 +330,13 @@ public class QuestionMetadataComplexQueriesRepositoryImpl implements QuestionMet
                                 "AND q.solution_steps <= :stepsMax " +
 
                                 "order by " +
+                                " (COALESCE(:deniedQuestionMetaIds) IS NULL OR q.name NOT IN (:deniedQuestionMetaIds)) DESC, " +
+                                " (COALESCE(:deniedQuestionNames) IS NULL OR q.name NOT IN (:deniedQuestionNames)) DESC, " +
+                                " (COALESCE(:deniedQuestionTemplateIds) IS NULL OR q.name NOT IN (:deniedQuestionTemplateIds)) DESC, " +
                                 " abs(q.integral_complexity - :complexity) DIV :complWindow ASC, " +
                                 " q.integral_complexity <= :complexity + :complWindow DESC, " +
                                 " (q.concept_bits & :deniedConceptBits) + (q.violation_bits & :deniedLawBits) ASC, " +
                                 " IF(:targetTagsBitmask <> 0, (q.tag_bits & :targetTagsBitmask) = :targetTagsBitmask, 1) DESC, " +
-                                " (COALESCE(:deniedQuestionNames) IS NULL OR q.name NOT IN (:deniedQuestionNames)) DESC, " +
-                                " (COALESCE(:deniedQuestionTemplateIds) IS NULL OR q.name NOT IN (:deniedQuestionTemplateIds)) DESC, " +
-                                " (COALESCE(:deniedQuestionMetaIds) IS NULL OR q.name NOT IN (:deniedQuestionMetaIds)) DESC, " +
                                 " (SELECT COUNT(*) FROM question WHERE metadata_id = q.id) ASC, " +  // less often show "hot" questions
                                 " (GREATEST(bit_count(q.trace_concept_bits & :unwantedConceptsBitmask), bit_count(q.concept_bits & :unwantedConceptsBitmask)) + bit_count(q.law_bits & :unwantedLawsBitmask) + bit_count(q.violation_bits & :unwantedViolationsBitmask)) DIV 3 ASC, " +
                                 " GREATEST(bit_count(q.trace_concept_bits & :targetConceptsBitmask), bit_count(q.concept_bits & :targetConceptsBitmask)) + bit_count(q.violation_bits & :targetLawsBitmask) DESC " +

--- a/modules/core/src/main/java/org/vstu/compprehension/models/repository/QuestionMetadataComplexQueriesRepositoryImpl.java
+++ b/modules/core/src/main/java/org/vstu/compprehension/models/repository/QuestionMetadataComplexQueriesRepositoryImpl.java
@@ -335,7 +335,7 @@ public class QuestionMetadataComplexQueriesRepositoryImpl implements QuestionMet
                                 " (COALESCE(:deniedQuestionTemplateIds) IS NULL OR q.name NOT IN (:deniedQuestionTemplateIds)) DESC, " +
                                 " abs(q.integral_complexity - :complexity) DIV :complWindow ASC, " +
                                 " q.integral_complexity <= :complexity + :complWindow DESC, " +
-                                " (q.concept_bits & :deniedConceptBits) + (q.violation_bits & :deniedLawBits) ASC, " +
+                                " bit_count(q.concept_bits & :deniedConceptBits) + bit_count(q.violation_bits & :deniedLawBits) ASC, " +
                                 " IF(:targetTagsBitmask <> 0, (q.tag_bits & :targetTagsBitmask) = :targetTagsBitmask, 1) DESC, " +
                                 " (SELECT COUNT(*) FROM question WHERE metadata_id = q.id) ASC, " +  // less often show "hot" questions
                                 " (GREATEST(bit_count(q.trace_concept_bits & :unwantedConceptsBitmask), bit_count(q.concept_bits & :unwantedConceptsBitmask)) + bit_count(q.law_bits & :unwantedLawsBitmask) + bit_count(q.violation_bits & :unwantedViolationsBitmask)) DIV 3 ASC, " +


### PR DESCRIPTION
• Improve QR preparation: drop nulls from denied lists
• findMetadataRelaxed: order by "denied" lists first, so used questions get lowest priority.
• minor (docstrings, etc)